### PR TITLE
feat(ci): add weekly scheduled wheel build matrix

### DIFF
--- a/.github/scripts/check_for_releases.sh
+++ b/.github/scripts/check_for_releases.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+UPSTREAM_REPO="${UPSTREAM_REPO:?UPSTREAM_REPO must be set, e.g. Dao-AILab/causal-conv1d}"
+LIMIT="${LIMIT:-3}"
+OUTPUT_FILE="${OUTPUT_FILE:-releases.json}"
+
+echo "Fetching last ${LIMIT} stable releases of ${UPSTREAM_REPO}..."
+echo "---------------------------------------------------------------------"
+
+gh release list \
+  --repo "$UPSTREAM_REPO" \
+  --limit "$LIMIT" \
+  --exclude-drafts \
+  --exclude-pre-releases \
+  --json tagName \
+  --jq '[.[].tagName]' \
+  > "$OUTPUT_FILE"
+
+echo "Resolved release tags:"
+cat "$OUTPUT_FILE"
+echo
+echo "---"
+echo "Check complete."

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -30,8 +30,15 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: Build wheel (${{ inputs.container-image }})
     steps:
-      - name: Move /var/lib/docker/
-        run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker"
+      - name: Move /var/lib/containerd/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/docker/containerd"
+          sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker/containerd"
+
+      - name: Move /var/lib/containerd/
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/docker/docker"
+          sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker/docker"
 
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
@@ -43,10 +50,13 @@ jobs:
           remove-android: "true"
           remove-haskell: "true"
           remove-codeql: "true"
-          build-mount-path: "/var/lib/docker/"
+          build-mount-path: "/var/lib/"
+
+      - name: Restore /var/lib/containerd/
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/containerd/* /var/lib/containerd"
 
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/docker/* /var/lib/docker"
 
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/build_in_container.yml
+++ b/.github/workflows/build_in_container.yml
@@ -12,6 +12,7 @@ on:
         description: "Container image"
         required: true
         type: string
+        default: "nvcr.io/nvidia/pytorch:25.06-py3"
       upload-to-release:
         description: "Upload wheel to this release"
         required: false
@@ -25,29 +26,10 @@ on:
   push:
 
 jobs:
-  check_for_ngc_images:
-    runs-on: ubuntu-latest
-    outputs:
-      images: ${{ steps.check_for_ngc_images.outputs.IMAGES }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Check for NGC PyTorch images
-        id: check_for_ngc_images
-        run: |
-          bash ./.github/scripts/check_for_ngc_images.sh
-          echo "IMAGES=$(cat ngc_images.json| jq -cr)" >> $GITHUB_OUTPUT
-
   build-wheels:
-    needs: [check_for_ngc_images]
     uses: ./.github/workflows/_build_in_container.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        container-image: ${{ fromJson(needs.check_for_ngc_images.outputs.images) }}
     with:
       runs-on: ${{ inputs.runs-on || 'ubuntu-22.04' }}
-      container-image: ${{ matrix.container-image }}
+      container-image: ${{ inputs.container-image || 'nvcr.io/nvidia/pytorch:25.06-py3' }}
       upload-to-release: ${{ inputs.upload-to-release || false }}
       release-version: ${{ inputs.release-version || 'v2.2.5' }}

--- a/.github/workflows/build_in_container_scheduled.yml
+++ b/.github/workflows/build_in_container_scheduled.yml
@@ -1,0 +1,48 @@
+name: Build wheels in a container (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.compute.outputs.RUNNERS }}
+      container-images: ${{ steps.compute.outputs.IMAGES }}
+      release-versions: ${{ steps.compute.outputs.RELEASES }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for NGC PyTorch images
+        run: bash ./.github/scripts/check_for_ngc_images.sh
+
+      - name: Check for upstream releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_REPO: Dao-AILab/causal-conv1d
+        run: bash ./.github/scripts/check_for_releases.sh
+
+      - name: Build matrix outputs
+        id: compute
+        run: |
+          echo "RUNNERS=$(jq -cn '["ubuntu-22.04","ubuntu-22.04-arm"]')" | tee -a "$GITHUB_OUTPUT"
+          echo "IMAGES=$(jq -cr . ngc_images.json)" | tee -a "$GITHUB_OUTPUT"
+          echo "RELEASES=$(jq -cr . releases.json)" | tee -a "$GITHUB_OUTPUT"
+
+  build-wheels:
+    needs: [compute_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.compute_matrix.outputs.runners) }}
+        container-image: ${{ fromJson(needs.compute_matrix.outputs.container-images) }}
+        release-version: ${{ fromJson(needs.compute_matrix.outputs.release-versions) }}
+    uses: ./.github/workflows/_build_in_container.yml
+    with:
+      runs-on: ${{ matrix.runner }}
+      container-image: ${{ matrix.container-image }}
+      upload-to-release: false
+      release-version: ${{ matrix.release-version }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Adds a weekly scheduled wheel-build pipeline that fans out across:

- **runners**: `ubuntu-22.04`, `ubuntu-22.04-arm`
- **container images**: last 7 `nvcr.io/nvidia/pytorch:YY.MM-py3` images (existing `check_for_ngc_images.sh`)
- **release versions**: last 3 stable upstream tags (new `check_for_releases.sh`, hits `Dao-AILab/causal-conv1d`)

Total: up to **42 jobs** per scheduled run.

Triggers on the new workflow:
- `schedule`: cron `0 6 * * 1` (Mondays 06:00 UTC)
- `workflow_dispatch`: manual run, full matrix

## Bug fix in `build_in_container.yml`

The existing workflow always fanned out across all 7 NGC images, even on `push` and `workflow_dispatch`, ignoring the `container-image` input. Removed the inline matrix so non-scheduled triggers now run a **single** config from inputs/defaults — matching the mamba workflow's shape. The fan-out lives in the new `*_scheduled.yml` only.

## Example matrix dimensions

```json
{
  "runner":          ["ubuntu-22.04", "ubuntu-22.04-arm"],
  "container-image": ["nvcr.io/nvidia/pytorch:26.04-py3", "..."],
  "release-version": ["v1.6.1.post4", "v1.6.1.post3", "v1.6.1.post2"]
}
```

</details>
